### PR TITLE
[🚀 사이클2 - 미션 (예약 변경/취소와 에러 처리)] 카야 미션 제출합니다.

### DIFF
--- a/src/main/java/roomescape/global/ErrorCode.java
+++ b/src/main/java/roomescape/global/ErrorCode.java
@@ -1,0 +1,8 @@
+package roomescape.global;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus status();
+    String message();
+}

--- a/src/main/java/roomescape/global/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/global/GlobalExceptionHandler.java
@@ -22,7 +22,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleRoomEscape(RoomEscapeException e) {
-        return createBadRequestResponse(e.getMessage());
+        return ResponseEntity
+                .status(e.errorCode().status())
+                .body(new ErrorResponse(e.getMessage()));
     }
 
     @ExceptionHandler

--- a/src/main/java/roomescape/global/RoomEscapeException.java
+++ b/src/main/java/roomescape/global/RoomEscapeException.java
@@ -1,7 +1,19 @@
 package roomescape.global;
 
 public class RoomEscapeException extends RuntimeException {
-    public RoomEscapeException(String message) {
-        super(message);
+    private final ErrorCode errorCode;
+
+    public RoomEscapeException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public RoomEscapeException(ErrorCode errorCode, Object... args) {
+        super(String.format(errorCode.message(), args));
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode errorCode() {
+        return errorCode;
     }
 }

--- a/src/main/java/roomescape/reservation/application/dto/ReservationUpdateCommand.java
+++ b/src/main/java/roomescape/reservation/application/dto/ReservationUpdateCommand.java
@@ -1,0 +1,11 @@
+package roomescape.reservation.application.dto;
+
+import java.time.LocalDate;
+
+public record ReservationUpdateCommand(
+        Long id,
+        String name,
+        LocalDate date,
+        Long timeId
+) {
+}

--- a/src/main/java/roomescape/reservation/application/exception/ReservationErrorCode.java
+++ b/src/main/java/roomescape/reservation/application/exception/ReservationErrorCode.java
@@ -1,0 +1,29 @@
+package roomescape.reservation.application.exception;
+
+import org.springframework.http.HttpStatus;
+import roomescape.global.ErrorCode;
+
+public enum ReservationErrorCode implements ErrorCode {
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
+    DUPLICATE_RESERVATION(HttpStatus.CONFLICT, "이미 해당 날짜와 시간에 예약이 존재합니다."),
+    PAST_RESERVATION_TIME(HttpStatus.UNPROCESSABLE_ENTITY, "현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ReservationErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/roomescape/reservation/application/exception/ReservationErrorCode.java
+++ b/src/main/java/roomescape/reservation/application/exception/ReservationErrorCode.java
@@ -6,7 +6,9 @@ import roomescape.global.ErrorCode;
 public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),
     DUPLICATE_RESERVATION(HttpStatus.CONFLICT, "이미 해당 날짜와 시간에 예약이 존재합니다."),
-    PAST_RESERVATION_TIME(HttpStatus.UNPROCESSABLE_ENTITY, "현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
+    PAST_RESERVATION_TIME(HttpStatus.UNPROCESSABLE_ENTITY, "현재 시간보다 이전 시간으로 예약을 할 수 없습니다."),
+    PAST_RESERVATION_MODIFICATION(HttpStatus.UNPROCESSABLE_ENTITY, "지난 예약은 변경하거나 취소할 수 없습니다."),
+    FORBIDDEN_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, "본인의 예약만 변경하거나 취소할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/roomescape/reservation/application/exception/ReservationException.java
+++ b/src/main/java/roomescape/reservation/application/exception/ReservationException.java
@@ -1,9 +1,0 @@
-package roomescape.reservation.application.exception;
-
-import roomescape.global.RoomEscapeException;
-
-public class ReservationException extends RoomEscapeException {
-    public ReservationException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/roomescape/reservation/application/service/ReservationQueryService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationQueryService.java
@@ -12,7 +12,7 @@ public class ReservationQueryService {
 
     private final ReservationQueryRepository queryRepository;
 
-    public boolean existsByTImeId(Long timeId) {
+    public boolean existsByTimeId(Long timeId) {
         return queryRepository.existsByTimeId(timeId);
     }
 

--- a/src/main/java/roomescape/reservation/application/service/ReservationQueryService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationQueryService.java
@@ -1,0 +1,22 @@
+package roomescape.reservation.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.reservation.domain.repository.ReservationQueryRepository;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ReservationQueryService {
+
+    private final ReservationQueryRepository queryRepository;
+
+    public boolean existsByTImeId(Long timeId) {
+        return queryRepository.existsByTimeId(timeId);
+    }
+
+    public boolean existsByThemeId(Long themeId) {
+        return queryRepository.existsByThemeId(themeId);
+    }
+}

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -57,31 +57,25 @@ public class ReservationService {
 
     public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
         ReservationDetail reservationDetail = getReservationDetail(request.id());
-        validateOwner(request.name(), reservationDetail);
+        Reservation reservation = toReservation(reservationDetail);
+        validateOwner(request.name(), reservation);
         validateReservationNotPast(reservationDetail, currentDateTime);
 
         ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
         validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
-        validateDuplicateReservation(request, reservationDetail);
+        validateDuplicateReservation(request, reservation);
 
-        Reservation updatedReservation = toReservation(reservationDetail).update(request.date(), request.timeId());
+        Reservation updatedReservation = reservation.update(request.date(), request.timeId());
         Reservation savedReservation = reservationRepository.update(updatedReservation);
         return toQueryResult(savedReservation);
     }
 
     public int delete(Long id, String name, LocalDateTime currentDateTime) {
         ReservationDetail reservationDetail = getReservationDetail(id);
-        validateOwner(name, reservationDetail);
+        Reservation reservation = toReservation(reservationDetail);
+        validateOwner(name, reservation);
         validateReservationNotPast(reservationDetail, currentDateTime);
         return reservationRepository.delete(id);
-    }
-
-    private void validateReservationDateTime(LocalDate date, LocalTime startAt, LocalDateTime currentDateTime) {
-        LocalDateTime triedDateTime = LocalDateTime.of(date, startAt);
-
-        if (triedDateTime.isBefore(currentDateTime)) {
-            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_TIME);
-        }
     }
 
     private ReservationDetail getReservationDetail(Long id) {
@@ -99,21 +93,29 @@ public class ReservationService {
         }
     }
 
-    private void validateDuplicateReservation(ReservationUpdateCommand request, ReservationDetail reservationDetail) {
+    private void validateDuplicateReservation(ReservationUpdateCommand request, Reservation reservation) {
         Boolean existsByDateAndTime = reservationRepository.existsByDateAndThemeAndTimeExcludingId(
                 request.date(),
-                reservationDetail.themeId(),
+                reservation.getThemeId(),
                 request.timeId(),
-                reservationDetail.reservationId()
+                reservation.getId()
         );
         if (existsByDateAndTime) {
             throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
         }
     }
 
-    private void validateOwner(String name, ReservationDetail reservationDetail) {
-        if (!reservationDetail.username().equals(name)) {
+    private void validateOwner(String name, Reservation reservation) {
+        if (!reservation.isOwner(name)) {
             throw new RoomEscapeException(ReservationErrorCode.FORBIDDEN_RESERVATION_ACCESS);
+        }
+    }
+
+    private void validateReservationDateTime(LocalDate date, LocalTime startAt, LocalDateTime currentDateTime) {
+        LocalDateTime triedDateTime = LocalDateTime.of(date, startAt);
+
+        if (triedDateTime.isBefore(currentDateTime)) {
+            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_TIME);
         }
     }
 

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -36,6 +36,13 @@ public class ReservationService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<ReservationQueryResult> findAllByName(String name) {
+        return reservationRepository.findByName(name).stream()
+                .map(this::toQueryResult)
+                .toList();
+    }
+
     public ReservationQueryResult save(ReservationCreateCommand request, LocalDateTime currentDateTime) {
         ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
         validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -56,23 +56,23 @@ public class ReservationService {
     }
 
     public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
-        Reservation reservation = getReservation(request.id());
-        validateOwner(request.name(), reservation);
-        validateReservationNotPast(reservation, currentDateTime);
+        ReservationDetail reservationDetail = getReservationDetail(request.id());
+        validateOwner(request.name(), reservationDetail);
+        validateReservationNotPast(reservationDetail, currentDateTime);
 
         ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
         validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
-        validateDuplicateReservation(request, reservation);
+        validateDuplicateReservation(request, reservationDetail);
 
-        Reservation updatedReservation = reservation.update(request.date(), request.timeId());
+        Reservation updatedReservation = toReservation(reservationDetail).update(request.date(), request.timeId());
         Reservation savedReservation = reservationRepository.update(updatedReservation);
         return toQueryResult(savedReservation);
     }
 
     public int delete(Long id, String name, LocalDateTime currentDateTime) {
-        Reservation reservation = getReservation(id);
-        validateOwner(name, reservation);
-        validateReservationNotPast(reservation, currentDateTime);
+        ReservationDetail reservationDetail = getReservationDetail(id);
+        validateOwner(name, reservationDetail);
+        validateReservationNotPast(reservationDetail, currentDateTime);
         return reservationRepository.delete(id);
     }
 
@@ -84,8 +84,8 @@ public class ReservationService {
         }
     }
 
-    private Reservation getReservation(Long id) {
-        return reservationRepository.findById(id)
+    private ReservationDetail getReservationDetail(Long id) {
+        return reservationRepository.findDetailById(id)
                 .orElseThrow(() -> new RoomEscapeException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }
 
@@ -99,27 +99,26 @@ public class ReservationService {
         }
     }
 
-    private void validateDuplicateReservation(ReservationUpdateCommand request, Reservation reservation) {
+    private void validateDuplicateReservation(ReservationUpdateCommand request, ReservationDetail reservationDetail) {
         Boolean existsByDateAndTime = reservationRepository.existsByDateAndThemeAndTimeExcludingId(
                 request.date(),
-                reservation.getThemeId(),
+                reservationDetail.themeId(),
                 request.timeId(),
-                reservation.getId()
+                reservationDetail.reservationId()
         );
         if (existsByDateAndTime) {
             throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
         }
     }
 
-    private void validateOwner(String name, Reservation reservation) {
-        if (!reservation.getName().equals(name)) {
+    private void validateOwner(String name, ReservationDetail reservationDetail) {
+        if (!reservationDetail.username().equals(name)) {
             throw new RoomEscapeException(ReservationErrorCode.FORBIDDEN_RESERVATION_ACCESS);
         }
     }
 
-    private void validateReservationNotPast(Reservation reservation, LocalDateTime currentDateTime) {
-        ReservationTimeQueryResult timeQueryResult = timeService.findById(reservation.getTimeId());
-        LocalDateTime reservationDateTime = LocalDateTime.of(reservation.getDate(), timeQueryResult.startAt());
+    private void validateReservationNotPast(ReservationDetail reservationDetail, LocalDateTime currentDateTime) {
+        LocalDateTime reservationDateTime = LocalDateTime.of(reservationDetail.date(), reservationDetail.startAt());
 
         if (reservationDateTime.isBefore(currentDateTime)) {
             throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_MODIFICATION);
@@ -130,5 +129,15 @@ public class ReservationService {
         ThemeQueryResult themeQueryResult = themeService.findById(reservation.getThemeId());
         ReservationTimeQueryResult timeQueryResult = timeService.findById(reservation.getTimeId());
         return ReservationQueryResult.from(reservation, themeQueryResult, timeQueryResult);
+    }
+
+    private Reservation toReservation(ReservationDetail reservationDetail) {
+        return Reservation.builder()
+                .id(reservationDetail.reservationId())
+                .name(reservationDetail.username())
+                .date(reservationDetail.date())
+                .themeId(reservationDetail.themeId())
+                .timeId(reservationDetail.timeId())
+                .build();
     }
 }

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.ReservationQueryResult;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.repository.ReservationDetail;
@@ -54,7 +55,24 @@ public class ReservationService {
         return ReservationQueryResult.from(reservationRepository.save(reservation), themeQueryResult, timeQueryResult);
     }
 
-    public int delete(Long id) {
+    public ReservationQueryResult update(ReservationUpdateCommand request, LocalDateTime currentDateTime) {
+        Reservation reservation = getReservation(request.id());
+        validateOwner(request.name(), reservation);
+        validateReservationNotPast(reservation, currentDateTime);
+
+        ReservationTimeQueryResult timeQueryResult = timeService.findById(request.timeId());
+        validateReservationDateTime(request.date(), timeQueryResult.startAt(), currentDateTime);
+        validateDuplicateReservation(request, reservation);
+
+        Reservation updatedReservation = reservation.update(request.date(), request.timeId());
+        Reservation savedReservation = reservationRepository.update(updatedReservation);
+        return toQueryResult(savedReservation);
+    }
+
+    public int delete(Long id, String name, LocalDateTime currentDateTime) {
+        Reservation reservation = getReservation(id);
+        validateOwner(name, reservation);
+        validateReservationNotPast(reservation, currentDateTime);
         return reservationRepository.delete(id);
     }
 
@@ -66,6 +84,11 @@ public class ReservationService {
         }
     }
 
+    private Reservation getReservation(Long id) {
+        return reservationRepository.findById(id)
+                .orElseThrow(() -> new RoomEscapeException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
     private void validateDuplicateReservation(ReservationCreateCommand request) {
         Boolean existsByDateAndTime = reservationRepository.existsByDateAndThemeAndTime(request.date(),
                 request.themeId(),
@@ -74,5 +97,38 @@ public class ReservationService {
         if (existsByDateAndTime) {
             throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
         }
+    }
+
+    private void validateDuplicateReservation(ReservationUpdateCommand request, Reservation reservation) {
+        Boolean existsByDateAndTime = reservationRepository.existsByDateAndThemeAndTimeExcludingId(
+                request.date(),
+                reservation.getThemeId(),
+                request.timeId(),
+                reservation.getId()
+        );
+        if (existsByDateAndTime) {
+            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
+        }
+    }
+
+    private void validateOwner(String name, Reservation reservation) {
+        if (!reservation.getName().equals(name)) {
+            throw new RoomEscapeException(ReservationErrorCode.FORBIDDEN_RESERVATION_ACCESS);
+        }
+    }
+
+    private void validateReservationNotPast(Reservation reservation, LocalDateTime currentDateTime) {
+        ReservationTimeQueryResult timeQueryResult = timeService.findById(reservation.getTimeId());
+        LocalDateTime reservationDateTime = LocalDateTime.of(reservation.getDate(), timeQueryResult.startAt());
+
+        if (reservationDateTime.isBefore(currentDateTime)) {
+            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_MODIFICATION);
+        }
+    }
+
+    private ReservationQueryResult toQueryResult(Reservation reservation) {
+        ThemeQueryResult themeQueryResult = themeService.findById(reservation.getThemeId());
+        ReservationTimeQueryResult timeQueryResult = timeService.findById(reservation.getTimeId());
+        return ReservationQueryResult.from(reservation, themeQueryResult, timeQueryResult);
     }
 }

--- a/src/main/java/roomescape/reservation/application/service/ReservationService.java
+++ b/src/main/java/roomescape/reservation/application/service/ReservationService.java
@@ -7,9 +7,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.ReservationQueryResult;
-import roomescape.reservation.application.exception.ReservationException;
+import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.repository.ReservationDetail;
 import roomescape.reservation.domain.repository.ReservationRepository;
@@ -54,7 +55,7 @@ public class ReservationService {
         LocalDateTime triedDateTime = LocalDateTime.of(date, startAt);
 
         if (triedDateTime.isBefore(currentDateTime)) {
-            throw new ReservationException("현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
+            throw new RoomEscapeException(ReservationErrorCode.PAST_RESERVATION_TIME);
         }
     }
 
@@ -64,7 +65,7 @@ public class ReservationService {
                 request.timeId()
         );
         if (existsByDateAndTime) {
-            throw new ReservationException("이미 해당 날짜와 시간에 예약이 존재합니다.");
+            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
         }
     }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -35,4 +35,8 @@ public class Reservation {
                 .timeId(timeId)
                 .build();
     }
+
+    public boolean isOwner(String name) {
+        return this.name.equals(name);
+    }
 }

--- a/src/main/java/roomescape/reservation/domain/Reservation.java
+++ b/src/main/java/roomescape/reservation/domain/Reservation.java
@@ -25,4 +25,14 @@ public class Reservation {
                 .timeId(this.timeId)
                 .build();
     }
+
+    public Reservation update(LocalDate date, Long timeId) {
+        return Reservation.builder()
+                .id(this.id)
+                .name(this.name)
+                .date(date)
+                .themeId(this.themeId)
+                .timeId(timeId)
+                .build();
+    }
 }

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationQueryRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationQueryRepository.java
@@ -1,0 +1,7 @@
+package roomescape.reservation.domain.repository;
+
+public interface ReservationQueryRepository {
+    boolean existsByTimeId(Long timeId);
+
+    boolean existsByThemeId(Long themeId);
+}

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -13,6 +13,8 @@ public interface ReservationRepository {
 
     Reservation save(Reservation reservation);
 
+    Reservation update(Reservation reservation);
+
     Integer delete(Long id);
 
     Boolean existsByDateAndThemeAndTime(LocalDate date, Long themeId, Long timeId);

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -7,6 +7,10 @@ import roomescape.reservation.domain.Reservation;
 public interface ReservationRepository {
     List<ReservationDetail> findAll();
 
+    List<Reservation> findByName(String name);
+
+    Optional<Reservation> findById(Long id);
+
     Reservation save(Reservation reservation);
 
     Integer delete(Long id);

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package roomescape.reservation.domain.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import roomescape.reservation.domain.Reservation;
 
 public interface ReservationRepository {
@@ -18,4 +19,6 @@ public interface ReservationRepository {
     Integer delete(Long id);
 
     Boolean existsByDateAndThemeAndTime(LocalDate date, Long themeId, Long timeId);
+
+    Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id);
 }

--- a/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/reservation/domain/repository/ReservationRepository.java
@@ -12,6 +12,8 @@ public interface ReservationRepository {
 
     Optional<Reservation> findById(Long id);
 
+    Optional<ReservationDetail> findDetailById(Long id);
+
     Reservation save(Reservation reservation);
 
     Reservation update(Reservation reservation);

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationQueryRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationQueryRepository.java
@@ -1,0 +1,38 @@
+package roomescape.reservation.infra;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import roomescape.reservation.domain.repository.ReservationQueryRepository;
+
+@Repository
+public class JdbcReservationQueryRepository implements ReservationQueryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert jdbcInsert;
+
+    public JdbcReservationQueryRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("reservation")
+                .usingGeneratedKeyColumns("id");
+    }
+
+    @Override
+    public boolean existsByTimeId(Long timeId) {
+        Integer result = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation WHRER time_id = ?"
+                , Integer.class
+                , timeId);
+        return result > 0;
+    }
+
+    @Override
+    public boolean existsByThemeId(Long themeId) {
+        Integer result = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation WHRER time_id = ?"
+                , Integer.class
+                , themeId);
+        return result > 0;
+    }
+}

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationQueryRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationQueryRepository.java
@@ -1,7 +1,6 @@
 package roomescape.reservation.infra;
 
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.reservation.domain.repository.ReservationQueryRepository;
 
@@ -9,30 +8,28 @@ import roomescape.reservation.domain.repository.ReservationQueryRepository;
 public class JdbcReservationQueryRepository implements ReservationQueryRepository {
 
     private final JdbcTemplate jdbcTemplate;
-    private final SimpleJdbcInsert jdbcInsert;
 
     public JdbcReservationQueryRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
-        this.jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
-                .withTableName("reservation")
-                .usingGeneratedKeyColumns("id");
     }
 
     @Override
     public boolean existsByTimeId(Long timeId) {
         Integer result = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM reservation WHRER time_id = ?"
-                , Integer.class
-                , timeId);
+                "SELECT COUNT(*) FROM reservation WHERE time_id = ?",
+                Integer.class,
+                timeId
+        );
         return result > 0;
     }
 
     @Override
     public boolean existsByThemeId(Long themeId) {
         Integer result = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM reservation WHRER time_id = ?"
-                , Integer.class
-                , themeId);
+                "SELECT COUNT(*) FROM reservation WHERE theme_id = ?",
+                Integer.class,
+                themeId
+        );
         return result > 0;
     }
 }

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
@@ -3,11 +3,14 @@ package roomescape.reservation.infra;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
+import roomescape.global.RoomEscapeException;
+import roomescape.reservation.application.exception.ReservationErrorCode;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.repository.ReservationDetail;
 import roomescape.reservation.domain.repository.ReservationRepository;
@@ -82,8 +85,12 @@ public class JdbcReservationRepository implements ReservationRepository {
                 .addValue("theme_id", reservation.getThemeId())
                 .addValue("time_id", reservation.getTimeId());
 
-        Long id = jdbcInsert.executeAndReturnKey(params).longValue();
-        return reservation.withId(id);
+        try {
+            Long id = jdbcInsert.executeAndReturnKey(params).longValue();
+            return reservation.withId(id);
+        } catch (DuplicateKeyException e) {
+            throw new RoomEscapeException(ReservationErrorCode.DUPLICATE_RESERVATION);
+        }
     }
 
     @Override

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
@@ -119,12 +119,17 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public Reservation update(Reservation reservation) {
-        jdbcTemplate.update(
+        int updatedRowCount = jdbcTemplate.update(
                 "UPDATE reservation SET date = ?, time_id = ? WHERE id = ?",
                 reservation.getDate(),
                 reservation.getTimeId(),
                 reservation.getId()
         );
+
+        if (updatedRowCount == 0) {
+            throw new RoomEscapeException(ReservationErrorCode.RESERVATION_NOT_FOUND);
+        }
+
         return reservation;
     }
 

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
@@ -78,6 +78,30 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public Optional<ReservationDetail> findDetailById(Long id) {
+        return jdbcTemplate.query(
+                """
+                        SELECT r.id, r.name, r.date, r.theme_id, t.name as theme_name, t.description, t.thumbnail_img_url, r.time_id, rt.start_at
+                        FROM reservation r
+                        JOIN theme t ON r.theme_id = t.id
+                        JOIN reservation_time rt ON r.time_id = rt.id
+                        WHERE r.id = ?
+                        """,
+                (rs, rowNum) ->
+                        new ReservationDetail(rs.getLong("id"),
+                                rs.getString("name"),
+                                rs.getDate("date").toLocalDate(),
+                                rs.getLong("theme_id"),
+                                rs.getString("theme_name"),
+                                rs.getString("description"),
+                                rs.getString("thumbnail_img_url"),
+                                rs.getLong("time_id"),
+                                rs.getTime("start_at").toLocalTime()),
+                id
+        ).stream().findFirst();
+    }
+
+    @Override
     public Reservation save(Reservation reservation) {
         SqlParameterSource params = new MapSqlParameterSource()
                 .addValue("name", reservation.getName())

--- a/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/reservation/infra/JdbcReservationRepository.java
@@ -2,6 +2,7 @@ package roomescape.reservation.infra;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -48,6 +49,32 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> findByName(String name) {
+        return jdbcTemplate.query(
+                "SELECT id, name, date, theme_id, time_id FROM reservation WHERE name = ? ORDER BY date ASC",
+                (rs, rowNum) -> mapReservation(rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getDate("date").toLocalDate(),
+                        rs.getLong("theme_id"),
+                        rs.getLong("time_id")),
+                name
+        );
+    }
+
+    @Override
+    public Optional<Reservation> findById(Long id) {
+        return jdbcTemplate.query(
+                "SELECT id, name, date, theme_id, time_id FROM reservation WHERE id = ?",
+                (rs, rowNum) -> mapReservation(rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getDate("date").toLocalDate(),
+                        rs.getLong("theme_id"),
+                        rs.getLong("time_id")),
+                id
+        ).stream().findFirst();
+    }
+
+    @Override
     public Reservation save(Reservation reservation) {
         SqlParameterSource params = new MapSqlParameterSource()
                 .addValue("name", reservation.getName())
@@ -57,6 +84,17 @@ public class JdbcReservationRepository implements ReservationRepository {
 
         Long id = jdbcInsert.executeAndReturnKey(params).longValue();
         return reservation.withId(id);
+    }
+
+    @Override
+    public Reservation update(Reservation reservation) {
+        jdbcTemplate.update(
+                "UPDATE reservation SET date = ?, time_id = ? WHERE id = ?",
+                reservation.getDate(),
+                reservation.getTimeId(),
+                reservation.getId()
+        );
+        return reservation;
     }
 
     @Override
@@ -72,5 +110,33 @@ public class JdbcReservationRepository implements ReservationRepository {
                 date,
                 themeId,
                 timeId);
+    }
+
+    @Override
+    public Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT EXISTS(
+                    SELECT 1
+                    FROM reservation
+                    WHERE date = ? AND theme_id = ? AND time_id = ? AND id <> ?
+                )
+                """,
+                Boolean.class,
+                date,
+                themeId,
+                timeId,
+                id
+        );
+    }
+
+    private Reservation mapReservation(Long id, String name, LocalDate date, Long themeId, Long timeId) {
+        return Reservation.builder()
+                .id(id)
+                .name(name)
+                .date(date)
+                .themeId(themeId)
+                .timeId(timeId)
+                .build();
     }
 }

--- a/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
@@ -8,15 +8,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservation.presentation.dto.ReservationCreateRequest;
 import roomescape.reservation.presentation.dto.ReservationResponse;
+import roomescape.reservation.presentation.dto.ReservationUpdateRequest;
 
 @RequiredArgsConstructor
 @RequestMapping("/reservations")

--- a/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
@@ -44,6 +44,18 @@ public class ReservationController {
                 .body(ReservationResponse.from(reservationService.save(createCommand, LocalDateTime.now())));
     }
 
+    @PatchMapping("/{id}")
+    public ResponseEntity<ReservationResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody ReservationUpdateRequest request
+    ) {
+        ReservationUpdateCommand command = request.toCommand(id);
+
+        return ResponseEntity.ok(
+                ReservationResponse.from(reservationService.update(command, LocalDateTime.now()))
+        );
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
             @PathVariable Long id

--- a/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
@@ -58,9 +58,10 @@ public class ReservationController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
-            @PathVariable Long id
+            @PathVariable Long id,
+            @RequestParam String name
     ) {
-        int deletedCount = reservationService.delete(id);
+        int deletedCount = reservationService.delete(id, name, LocalDateTime.now());
 
         if (deletedCount == 0) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/roomescape/reservation/presentation/controller/ReservationController.java
@@ -26,8 +26,8 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @GetMapping
-    public ResponseEntity<List<ReservationResponse>> findAll() {
-        List<ReservationResponse> responses = reservationService.findAll().stream()
+    public ResponseEntity<List<ReservationResponse>> findAll(@RequestParam String name) {
+        List<ReservationResponse> responses = reservationService.findAllByName(name).stream()
                 .map(ReservationResponse::from)
                 .toList();
 

--- a/src/main/java/roomescape/reservation/presentation/dto/ReservationUpdateRequest.java
+++ b/src/main/java/roomescape/reservation/presentation/dto/ReservationUpdateRequest.java
@@ -1,0 +1,21 @@
+package roomescape.reservation.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
+
+public record ReservationUpdateRequest(
+        @NotBlank(message = "[ERROR] 이름은 비어있을 수 없습니다.")
+        String name,
+        @NotNull(message = "[ERROR] 날짜는 비어있을 수 없습니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate date,
+        @NotNull(message = "[ERROR] 시간은 비어있을 수 없습니다.")
+        Long timeId
+) {
+    public ReservationUpdateCommand toCommand(Long id) {
+        return new ReservationUpdateCommand(id, name, date, timeId);
+    }
+}

--- a/src/main/java/roomescape/reservationtime/application/exception/ReservationTimeErrorCode.java
+++ b/src/main/java/roomescape/reservationtime/application/exception/ReservationTimeErrorCode.java
@@ -1,0 +1,28 @@
+package roomescape.reservationtime.application.exception;
+
+import org.springframework.http.HttpStatus;
+import roomescape.global.ErrorCode;
+
+public enum ReservationTimeErrorCode implements ErrorCode {
+    TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 시간 입니다."),
+    DUPLICATE_TIME(HttpStatus.CONFLICT, "시간 %s이(가) 이미 존재합니다."),
+    TIME_DELETE_NOT_ALLOWED(HttpStatus.UNPROCESSABLE_ENTITY, "예약이 존재하는 시간대는 삭제할 수 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ReservationTimeErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/roomescape/reservationtime/application/exception/ReservationTimeException.java
+++ b/src/main/java/roomescape/reservationtime/application/exception/ReservationTimeException.java
@@ -1,9 +1,0 @@
-package roomescape.reservationtime.application.exception;
-
-import roomescape.global.RoomEscapeException;
-
-public class ReservationTimeException extends RoomEscapeException {
-    public ReservationTimeException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/roomescape/reservationtime/application/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/reservationtime/application/service/ReservationTimeService.java
@@ -7,12 +7,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.service.ReservationQueryService;
-import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservationtime.application.dto.AvailableReservationTimeQueryResult;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
 import roomescape.reservationtime.application.dto.ReservationTimeQueryResult;
-import roomescape.reservationtime.application.exception.ReservationTimeException;
+import roomescape.reservationtime.application.exception.ReservationTimeErrorCode;
 import roomescape.reservationtime.domain.ReservationTime;
 import roomescape.reservationtime.domain.repository.AvailableReservationTime;
 import roomescape.reservationtime.domain.repository.AvailableReservationTimeRepository;
@@ -30,7 +30,7 @@ public class ReservationTimeService {
     @Transactional(readOnly = true)
     public ReservationTimeQueryResult findById(Long timeId) {
         return ReservationTimeQueryResult.from(timeRepository.findById(timeId)
-                .orElseThrow(() -> new ReservationTimeException("존재하지 않는 시간 입니다.")));
+                .orElseThrow(() -> new RoomEscapeException(ReservationTimeErrorCode.TIME_NOT_FOUND)));
     }
 
     @Transactional(readOnly = true)
@@ -65,15 +65,17 @@ public class ReservationTimeService {
     }
 
     private void validateNoReservationExists(Long id) {
-        if (queryService.existsByTImeId(id)) {
-            throw new ReservationTimeException("예약이 존재하는 시간대는 삭제할 수 없습니다");
+        if (queryService.existsByTimeId(id)) {
+            throw new RoomEscapeException(ReservationTimeErrorCode.TIME_DELETE_NOT_ALLOWED);
         }
     }
 
     private void validateDuplicateTime(LocalTime startAt) {
         if (timeRepository.existsByStartAt(startAt)) {
-            throw new ReservationTimeException(String.format("시간 %s이(가) 이미 존재합니다.",
-                    startAt.format(DateTimeFormatter.ofPattern("HH:mm"))));
+            throw new RoomEscapeException(
+                    ReservationTimeErrorCode.DUPLICATE_TIME,
+                    startAt.format(DateTimeFormatter.ofPattern("HH:mm"))
+            );
         }
     }
 }

--- a/src/main/java/roomescape/reservationtime/application/service/ReservationTimeService.java
+++ b/src/main/java/roomescape/reservationtime/application/service/ReservationTimeService.java
@@ -7,6 +7,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.reservation.application.service.ReservationQueryService;
+import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservationtime.application.dto.AvailableReservationTimeQueryResult;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
 import roomescape.reservationtime.application.dto.ReservationTimeQueryResult;
@@ -23,6 +25,7 @@ public class ReservationTimeService {
 
     private final ReservationTimeRepository timeRepository;
     private final AvailableReservationTimeRepository availableTimeRepository;
+    private final ReservationQueryService queryService;
 
     @Transactional(readOnly = true)
     public ReservationTimeQueryResult findById(Long timeId) {
@@ -57,7 +60,14 @@ public class ReservationTimeService {
     }
 
     public int delete(Long id) {
+        validateNoReservationExists(id);
         return timeRepository.delete(id);
+    }
+
+    private void validateNoReservationExists(Long id) {
+        if (queryService.existsByTImeId(id)) {
+            throw new ReservationTimeException("예약이 존재하는 시간대는 삭제할 수 없습니다");
+        }
     }
 
     private void validateDuplicateTime(LocalTime startAt) {

--- a/src/main/java/roomescape/theme/application/exception/ThemeErrorCode.java
+++ b/src/main/java/roomescape/theme/application/exception/ThemeErrorCode.java
@@ -1,0 +1,28 @@
+package roomescape.theme.application.exception;
+
+import org.springframework.http.HttpStatus;
+import roomescape.global.ErrorCode;
+
+public enum ThemeErrorCode implements ErrorCode {
+    THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 테마 입니다."),
+    DUPLICATE_THEME(HttpStatus.CONFLICT, "이름과 설명이 같은 테마가 이미 존재합니다."),
+    THEME_DELETE_NOT_ALLOWED(HttpStatus.UNPROCESSABLE_ENTITY, "예약이 존재하는 테마는 삭제할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ThemeErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/roomescape/theme/application/exception/ThemeException.java
+++ b/src/main/java/roomescape/theme/application/exception/ThemeException.java
@@ -1,9 +1,0 @@
-package roomescape.theme.application.exception;
-
-import roomescape.global.RoomEscapeException;
-
-public class ThemeException extends RoomEscapeException {
-    public ThemeException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/roomescape/theme/application/service/ThemeService.java
+++ b/src/main/java/roomescape/theme/application/service/ThemeService.java
@@ -5,11 +5,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.theme.application.dto.PopularThemeQueryResult;
 import roomescape.theme.application.dto.ThemeCreateCommand;
 import roomescape.theme.application.dto.ThemeQueryResult;
-import roomescape.theme.application.exception.ThemeException;
+import roomescape.theme.application.exception.ThemeErrorCode;
 import roomescape.theme.domain.Theme;
 import roomescape.theme.domain.repository.ThemeRepository;
 
@@ -24,7 +25,7 @@ public class ThemeService {
     @Transactional(readOnly = true)
     public ThemeQueryResult findById(Long id) {
         return ThemeQueryResult.from(themeRepository.findById(id)
-                .orElseThrow(() -> new ThemeException("존재하지 않는 테마 입니다.")));
+                .orElseThrow(() -> new RoomEscapeException(ThemeErrorCode.THEME_NOT_FOUND)));
     }
 
     @Transactional(readOnly = true)
@@ -57,13 +58,13 @@ public class ThemeService {
 
     private void validateNoReReservationExists(long id) {
         if (queryService.existsByThemeId(id)) {
-            throw new ThemeException("예약이 존재하는 테마는 삭제할 수 없습니다");
+            throw new RoomEscapeException(ThemeErrorCode.THEME_DELETE_NOT_ALLOWED);
         }
     }
 
     private void validateDuplicateTheme(Theme theme) {
         if (themeRepository.existsByNameAndDescription(theme)) {
-            throw new ThemeException("이름과 설명이 같은 테마가 이미 존재합니다.");
+            throw new RoomEscapeException(ThemeErrorCode.DUPLICATE_THEME);
         }
     }
 }

--- a/src/main/java/roomescape/theme/application/service/ThemeService.java
+++ b/src/main/java/roomescape/theme/application/service/ThemeService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.theme.application.dto.PopularThemeQueryResult;
 import roomescape.theme.application.dto.ThemeCreateCommand;
 import roomescape.theme.application.dto.ThemeQueryResult;
@@ -18,6 +19,7 @@ import roomescape.theme.domain.repository.ThemeRepository;
 public class ThemeService {
 
     private final ThemeRepository themeRepository;
+    private final ReservationQueryService queryService;
 
     @Transactional(readOnly = true)
     public ThemeQueryResult findById(Long id) {
@@ -49,7 +51,14 @@ public class ThemeService {
     }
 
     public int delete(long id) {
+        validateNoReReservationExists(id);
         return themeRepository.delete(id);
+    }
+
+    private void validateNoReReservationExists(long id) {
+        if (queryService.existsByThemeId(id)) {
+            throw new ThemeException("예약이 존재하는 테마는 삭제할 수 없습니다");
+        }
     }
 
     private void validateDuplicateTheme(Theme theme) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -23,6 +23,4 @@ CREATE TABLE reservation
     time_id  BIGINT       NOT NULL,
     PRIMARY KEY (id),
     CONSTRAINT uq_reservation_date_theme_time UNIQUE (date, theme_id, time_id),
-    FOREIGN KEY (theme_id) REFERENCES theme (id) ON DELETE CASCADE,
-    FOREIGN KEY (time_id) REFERENCES reservation_time (id) ON DELETE CASCADE
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,5 +22,5 @@ CREATE TABLE reservation
     theme_id BIGINT       NOT NULL,
     time_id  BIGINT       NOT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT uq_reservation_date_theme_time UNIQUE (date, theme_id, time_id),
+    CONSTRAINT uq_reservation_date_theme_time UNIQUE (date, theme_id, time_id)
 );

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -46,6 +46,11 @@ function applyRoute() {
         return;
     }
 
+    if (route === "reservations") {
+        state.route = "reservations";
+        return;
+    }
+
     state.route = "reserve";
 }
 
@@ -53,7 +58,14 @@ async function handleClick(event) {
     const routeButton = event.target.closest("[data-route]");
     if (routeButton) {
         const route = routeButton.dataset.route;
-        location.hash = route === "admin" ? `#/admin/${state.adminTab}` : "#/reserve";
+        if (route !== "reservations" && state.editingReservationId) {
+            cancelReservationEditing();
+        }
+        if (route === "admin") {
+            location.hash = `#/admin/${state.adminTab}`;
+            return;
+        }
+        location.hash = route === "reservations" ? "#/reservations" : "#/reserve";
         return;
     }
 
@@ -110,6 +122,16 @@ async function handleClick(event) {
             return;
         }
 
+        if (action === "edit-reservation") {
+            await startReservationEdit(Number(actionTarget.dataset.reservationId));
+            return;
+        }
+
+        if (action === "cancel-editing") {
+            cancelReservationEditing();
+            return;
+        }
+
         if (action === "cancel-confirm") {
             if (event.target !== actionTarget && actionTarget.classList.contains("modal-backdrop")) {
                 return;
@@ -140,7 +162,6 @@ async function handleClick(event) {
     if (timeButton && !timeButton.disabled) {
         state.selectedTimeId = Number(timeButton.dataset.timeSlotId);
         render();
-        appEl.querySelector("#guest-name")?.focus();
         return;
     }
 
@@ -152,6 +173,11 @@ async function handleClick(event) {
 
 async function handleSubmit(event) {
     event.preventDefault();
+
+    if (event.target.id === "reservation-lookup-form") {
+        await submitReservationLookup(event.target);
+        return;
+    }
 
     if (event.target.id === "reservation-form") {
         await submitReservation(event.target);
@@ -183,6 +209,11 @@ function handleInput(event) {
     if (event.target.id === "guest-name") {
         state.guestName = event.target.value;
         syncReservationButton();
+        return;
+    }
+
+    if (event.target.id === "reservation-name") {
+        state.guestName = event.target.value;
         return;
     }
 
@@ -221,17 +252,16 @@ async function refreshEverything() {
 }
 
 async function loadAllData() {
-    const [themes, popularThemes, adminTimes, reservations] = await Promise.all([
+    const [themes, popularThemes, adminTimes] = await Promise.all([
         api("/themes"),
         api("/themes/popular-top-10"),
-        api("/admin/times"),
-        api("/reservations")
+        api("/admin/times")
     ]);
 
     state.themes = themes;
     state.popularThemes = popularThemes;
     state.adminTimes = adminTimes;
-    state.reservations = reservations;
+    await loadReservations({silent: true});
 }
 
 async function loadAvailableTimes(options = {}) {
@@ -264,8 +294,8 @@ async function loadAvailableTimes(options = {}) {
 }
 
 async function submitReservation(form) {
-    const formData = new FormData(form);
-    const name = String(formData.get("name") || "").trim();
+    const name = state.guestName.trim();
+    const isEditing = Boolean(state.editingReservationId);
     let submitted = false;
 
     state.guestName = name;
@@ -280,22 +310,33 @@ async function submitReservation(form) {
     render();
 
     try {
-        await api("/reservations", {
-            method: "POST",
-            body: {
-                name,
-                date: state.selectedDate,
-                themeId: state.selectedThemeId,
-                timeId: state.selectedTimeId
-            }
-        });
+        if (state.editingReservationId) {
+            await api(`/reservations/${state.editingReservationId}`, {
+                method: "PATCH",
+                body: {
+                    name,
+                    date: state.selectedDate,
+                    timeId: state.selectedTimeId
+                }
+            });
+        } else {
+            await api("/reservations", {
+                method: "POST",
+                body: {
+                    name,
+                    date: state.selectedDate,
+                    themeId: state.selectedThemeId,
+                    timeId: state.selectedTimeId
+                }
+            });
+        }
 
-        state.guestName = "";
         state.selectedThemeId = null;
         state.selectedTimeId = null;
         state.availableTimes = [];
+        state.editingReservationId = null;
         await loadAllData({silent: true});
-        showToast("예약이 완료되었습니다.", "success");
+        showToast(isEditing ? "예약을 변경했습니다." : "예약이 완료되었습니다.", "success");
         submitted = true;
     } catch (error) {
         showToast(error.message, "error");
@@ -380,7 +421,36 @@ async function deleteTime(timeId) {
 }
 
 async function deleteReservation(reservationId) {
-    await mutateWithReload(() => api(`/reservations/${reservationId}`, {method: "DELETE"}), "예약을 삭제했습니다.");
+    const name = state.guestName.trim();
+
+    if (!name) {
+        showToast("예약자를 입력한 뒤 삭제해 주세요.", "error");
+        return;
+    }
+
+    const params = new URLSearchParams({name});
+    await mutateWithReload(() => api(`/reservations/${reservationId}?${params.toString()}`, {method: "DELETE"}), "예약을 삭제했습니다.");
+
+    if (Number(state.editingReservationId) === Number(reservationId)) {
+        cancelReservationEditing();
+    }
+}
+
+async function startReservationEdit(reservationId) {
+    const reservation = state.myReservations.find((item) => Number(item.id) === Number(reservationId));
+
+    if (!reservation) {
+        showToast("선택한 예약을 찾을 수 없습니다.", "error");
+        return;
+    }
+
+    state.editingReservationId = reservation.id;
+    state.guestName = reservation.name;
+    state.selectedThemeId = reservation.theme.id;
+    state.selectedDate = reservation.date;
+    state.selectedTimeId = reservation.time.id;
+    render();
+    await loadAvailableTimes();
 }
 
 async function mutateWithReload(request, successMessage) {
@@ -416,8 +486,15 @@ function ensureSelectedTheme() {
 function closeBookingPanel() {
     state.selectedThemeId = null;
     state.selectedTimeId = null;
+    state.editingReservationId = null;
     state.availableTimes = [];
     state.loading.times = false;
+}
+
+function cancelReservationEditing() {
+    state.editingReservationId = null;
+    state.selectedTimeId = null;
+    render();
 }
 
 function shouldCloseBookingFromBlankClick(event) {
@@ -456,6 +533,36 @@ function syncReservationButton() {
     }
 
     button.disabled = !canSubmitReservation();
+}
+
+async function loadReservations(options = {}) {
+    const name = state.guestName.trim();
+
+    if (!name) {
+        state.myReservations = [];
+        if (!options.silent) {
+            render();
+        }
+        return;
+    }
+
+    try {
+        const params = new URLSearchParams({name});
+        state.myReservations = await api(`/reservations?${params.toString()}`);
+    } catch (error) {
+        state.myReservations = [];
+        showToast(error.message, "error");
+    } finally {
+        if (!options.silent) {
+            render();
+        }
+    }
+}
+
+async function submitReservationLookup(form) {
+    const formData = new FormData(form);
+    state.guestName = String(formData.get("name") || "").trim();
+    await loadReservations();
 }
 
 function openConfirm(title, body, onConfirm) {

--- a/src/main/resources/static/js/render.js
+++ b/src/main/resources/static/js/render.js
@@ -16,11 +16,23 @@ export function render(options = {}) {
 
     appEl.innerHTML = `
     ${renderHeader()}
-    ${state.route === "admin" ? renderAdmin() : renderReserve()}
+    ${renderCurrentPage()}
   `;
     modalRootEl.innerHTML = renderConfirm();
     toastRootEl.innerHTML = renderToast();
     syncThemeFilter();
+}
+
+function renderCurrentPage() {
+    if (state.route === "admin") {
+        return renderAdmin();
+    }
+
+    if (state.route === "reservations") {
+        return renderReservationLookupPage();
+    }
+
+    return renderReserve();
 }
 
 export function syncThemeFilter() {
@@ -35,6 +47,7 @@ export function syncThemeFilter() {
 
 function renderHeader() {
     const reserveActive = state.route === "reserve";
+    const reservationsActive = state.route === "reservations";
     const adminActive = state.route === "admin";
 
     return `
@@ -49,6 +62,7 @@ function renderHeader() {
         </button>
         <nav class="header-nav" aria-label="주요 화면">
           <button class="${reserveActive ? "is-active" : ""}" type="button" data-route="reserve">예약</button>
+          <button class="${reservationsActive ? "is-active" : ""}" type="button" data-route="reservations">예약보기</button>
           <button class="${adminActive ? "is-active" : ""}" type="button" data-route="admin">운영</button>
         </nav>
       </div>
@@ -72,7 +86,7 @@ function renderReserve() {
         <div class="metric-row" aria-label="예약 현황">
           ${renderMetric(state.themes.length, "테마")}
           ${renderMetric(popular.length, "인기")}
-          ${renderMetric(state.reservations.length, "예약")}
+          ${renderMetric(state.availableTimes.filter((time) => time.available).length, "가능 시간")}
         </div>
       </section>
 
@@ -84,26 +98,30 @@ function renderReserve() {
         ${theme ? `
           <aside class="booking-panel" aria-labelledby="booking-title">
             <form id="reservation-form">
-              <div class="booking-header">
-                <div>
-                  <p class="section-kicker">Order</p>
-                  <h2 id="booking-title">예약 정보</h2>
+                <div class="booking-header">
+                  <div>
+                    <p class="section-kicker">Order</p>
+                    <h2 id="booking-title">${state.editingReservationId ? "예약 변경" : "예약 정보"}</h2>
+                    ${state.editingReservationId ? `<span class="booking-mode-note">현재 예약을 수정하는 중입니다.</span>` : ""}
+                  </div>
+                  <div class="booking-header-actions">
+                    ${state.editingReservationId ? `<button class="secondary-button compact" type="button" data-action="cancel-editing">변경 취소</button>` : ""}
+                    <button class="booking-close-button" type="button" data-action="close-booking" aria-label="예약 정보 닫기">×</button>
+                  </div>
                 </div>
-                <button class="booking-close-button" type="button" data-action="close-booking" aria-label="예약 정보 닫기">×</button>
-              </div>
               ${renderSelectedTheme(theme)}
               ${renderReservationFields()}
               ${renderTimeSlots()}
               ${renderBookingSummary(theme)}
               <button class="primary-button submit-button" type="submit" ${canSubmitReservation() ? "" : "disabled"}>
-                ${state.submitting ? "예약 중" : "예약하기"}
+                ${state.submitting ? (state.editingReservationId ? "변경 중" : "예약 중") : (state.editingReservationId ? "변경하기" : "예약하기")}
               </button>
             </form>
           </aside>
         ` : ""}
 
         <section class="theme-section" aria-labelledby="theme-section-title">
-          <div class="section-toolbar">
+          <div class="section-toolbar theme-toolbar">
             <div>
               <p class="section-kicker">Theme List</p>
               <h2 id="theme-section-title">전체 테마</h2>
@@ -118,6 +136,57 @@ function renderReserve() {
 
           ${renderThemeGrid()}
         </section>
+      </section>
+    </main>
+  `;
+}
+
+function renderReservationLookupPage() {
+    const editingReservation = state.editingReservationId ? state.myReservations.find((reservation) => Number(reservation.id) === Number(state.editingReservationId)) : null;
+
+    return `
+    <main class="page-shell">
+      <section class="headline-row">
+        <div>
+          <p class="section-kicker">My Reservation</p>
+          <h1>예약 조회 및 변경</h1>
+          <p>이름으로 본인 예약을 조회하고 날짜와 시간을 변경하거나 취소할 수 있습니다.</p>
+        </div>
+        <div class="metric-row" aria-label="내 예약 현황">
+          ${renderMetric(state.myReservations.length, "내 예약")}
+          ${renderMetric(editingReservation ? 1 : 0, "변경 중")}
+        </div>
+      </section>
+
+      <section class="lookup-layout">
+        <section class="theme-section" aria-labelledby="reservation-lookup-title">
+          ${renderReservationLookup()}
+          ${renderMyReservations()}
+        </section>
+
+        ${editingReservation ? `
+          <section class="theme-section reservation-edit-section" aria-labelledby="lookup-booking-title">
+            <form id="reservation-form">
+              <div class="booking-header">
+                <div>
+                  <p class="section-kicker">Update</p>
+                  <h2 id="lookup-booking-title">예약 변경</h2>
+                  <span class="booking-mode-note">조회한 예약의 날짜와 시간을 수정합니다.</span>
+                </div>
+                <div class="booking-header-actions">
+                  <button class="secondary-button compact" type="button" data-action="cancel-editing">변경 취소</button>
+                </div>
+              </div>
+              ${renderSelectedTheme(selectedTheme())}
+              ${renderReservationFields()}
+              ${renderTimeSlots()}
+              ${renderBookingSummary(selectedTheme())}
+              <button class="primary-button submit-button" type="submit" ${canSubmitReservation() ? "" : "disabled"}>
+                ${state.submitting ? "변경 중" : "변경하기"}
+              </button>
+            </form>
+          </section>
+        ` : ""}
       </section>
     </main>
   `;
@@ -206,7 +275,7 @@ function renderSelectedTheme(theme) {
     return `
     <div class="selected-theme">
       <div class="selected-copy">
-        <span>선택한 테마</span>
+        <span>${state.editingReservationId ? "변경할 테마" : "선택한 테마"}</span>
         <strong>${escapeHtml(theme.name)}</strong>
         <p>${escapeHtml(theme.description)}</p>
       </div>
@@ -217,12 +286,12 @@ function renderSelectedTheme(theme) {
 function renderReservationFields() {
     return `
     <div class="form-row">
-      <label for="reservation-date">날짜</label>
-      <input id="reservation-date" name="date" type="date" min="${todayString()}" value="${escapeAttr(state.selectedDate)}">
+      <label for="guest-name">예약자</label>
+      <input id="guest-name" name="name" type="text" value="${escapeAttr(state.guestName)}" placeholder="이름" ${state.editingReservationId ? "readonly" : ""}>
     </div>
     <div class="form-row">
-      <label for="guest-name">예약자</label>
-      <input id="guest-name" name="name" type="text" value="${escapeAttr(state.guestName)}" placeholder="이름">
+      <label for="reservation-date">날짜</label>
+      <input id="reservation-date" name="date" type="date" min="${todayString()}" value="${escapeAttr(state.selectedDate)}">
     </div>
   `;
 }
@@ -268,6 +337,10 @@ function renderBookingSummary(theme) {
     return `
     <dl class="booking-summary">
       <div>
+        <dt>예약자</dt>
+        <dd>${escapeHtml(state.guestName || "-")}</dd>
+      </div>
+      <div>
         <dt>테마</dt>
         <dd>${theme ? escapeHtml(theme.name) : "-"}</dd>
       </div>
@@ -275,7 +348,80 @@ function renderBookingSummary(theme) {
         <dt>일정</dt>
         <dd>${escapeHtml(state.selectedDate || "-")} ${time ? escapeHtml(time.startAt) : ""}</dd>
       </div>
+      <div>
+        <dt>모드</dt>
+        <dd>${state.editingReservationId ? "예약 변경" : "새 예약"}</dd>
+      </div>
     </dl>
+  `;
+}
+
+function renderReservationLookup() {
+    return `
+    <section class="reservation-lookup-section" aria-labelledby="reservation-lookup-title">
+      <div class="section-toolbar compact">
+        <div>
+          <p class="section-kicker">My Reservation</p>
+          <h2 id="reservation-lookup-title">내 예약 조회</h2>
+          <p class="section-copy">예약자 이름으로 예약을 확인하고 변경하거나 취소할 수 있습니다.</p>
+        </div>
+      </div>
+      <form id="reservation-lookup-form" class="lookup-row">
+        <label class="search-field wide" for="reservation-name">
+          <span>예약자 이름</span>
+          <input id="reservation-name" name="name" type="text" value="${escapeAttr(state.guestName)}" placeholder="이름을 입력해 내 예약을 조회하세요">
+        </label>
+        <button class="secondary-button lookup-submit" type="submit">조회</button>
+      </form>
+    </section>
+  `;
+}
+
+function renderMyReservations() {
+    const hasName = Boolean(state.guestName.trim());
+
+    return `
+    <section class="my-reservations-section" aria-labelledby="my-reservations-title">
+      <div class="admin-panel-header">
+        <div>
+          <p class="section-kicker">My Reservation</p>
+          <h2 id="my-reservations-title">내 예약</h2>
+        </div>
+      </div>
+      ${renderMyReservationsContent(hasName)}
+    </section>
+  `;
+}
+
+function renderMyReservationsContent(hasName) {
+    if (!hasName) {
+        return renderEmpty("예약자 이름을 입력하면 내 예약을 확인할 수 있습니다.");
+    }
+
+    if (state.myReservations.length === 0) {
+        return renderEmpty("조회된 예약이 없습니다.");
+    }
+
+    return `
+    <div class="reservation-table" role="table" aria-label="내 예약 목록">
+      <div class="table-head" role="row">
+        <span>예약자</span>
+        <span>테마</span>
+        <span>일정</span>
+        <span>관리</span>
+      </div>
+      ${state.myReservations.map((reservation) => `
+        <div class="table-row" role="row">
+          <span>${escapeHtml(reservation.name)}</span>
+          <span>${escapeHtml(reservation.theme.name)}</span>
+          <span>${escapeHtml(reservation.date)} ${escapeHtml(reservation.time.startAt)}</span>
+          <span class="table-actions">
+            <button class="secondary-button" type="button" data-action="edit-reservation" data-reservation-id="${reservation.id}">변경</button>
+            <button class="danger-button" type="button" data-action="delete-reservation" data-reservation-id="${reservation.id}">취소</button>
+          </span>
+        </div>
+      `).join("")}
+    </div>
   `;
 }
 
@@ -291,15 +437,13 @@ function renderAdmin() {
         <div class="metric-row" aria-label="운영 현황">
           ${renderMetric(state.themes.length, "테마")}
           ${renderMetric(state.adminTimes.length, "시간")}
-          ${renderMetric(state.reservations.length, "예약")}
         </div>
       </section>
 
-      <section class="admin-layout">
+        <section class="admin-layout">
         <aside class="admin-tabs" aria-label="운영 메뉴">
           ${renderAdminTab("themes", "테마")}
           ${renderAdminTab("times", "시간")}
-          ${renderAdminTab("reservations", "예약")}
         </aside>
         <section class="admin-panel">
           ${renderAdminPanel()}
@@ -320,10 +464,6 @@ function renderAdminTab(tab, label) {
 function renderAdminPanel() {
     if (state.adminTab === "times") {
         return renderTimesAdmin();
-    }
-
-    if (state.adminTab === "reservations") {
-        return renderReservationsAdmin();
     }
 
     return renderThemesAdmin();
@@ -395,35 +535,6 @@ function renderTimesAdmin() {
           <button class="danger-button" type="button" data-action="delete-time" data-time-id="${time.id}">삭제</button>
         </div>
       `).join("") || renderEmpty("등록된 시간이 없습니다.")}
-    </div>
-  `;
-}
-
-function renderReservationsAdmin() {
-    return `
-    <div class="admin-panel-header">
-      <div>
-        <p class="section-kicker">Reservation</p>
-        <h2>예약 목록</h2>
-      </div>
-      <button class="secondary-button" type="button" data-action="refresh-all">새로고침</button>
-    </div>
-
-    <div class="reservation-table" role="table" aria-label="예약 목록">
-      <div class="table-head" role="row">
-        <span>예약자</span>
-        <span>테마</span>
-        <span>일정</span>
-        <span></span>
-      </div>
-      ${state.reservations.map((reservation) => `
-        <div class="table-row" role="row">
-          <span>${escapeHtml(reservation.name)}</span>
-          <span>${escapeHtml(reservation.theme.name)}</span>
-          <span>${escapeHtml(reservation.date)} ${escapeHtml(reservation.time.startAt)}</span>
-          <span><button class="danger-button" type="button" data-action="delete-reservation" data-reservation-id="${reservation.id}">삭제</button></span>
-        </div>
-      `).join("") || renderEmpty("예약이 없습니다.")}
     </div>
   `;
 }

--- a/src/main/resources/static/js/state.js
+++ b/src/main/resources/static/js/state.js
@@ -1,4 +1,4 @@
-export const ADMIN_TABS = new Set(["themes", "times", "reservations"]);
+export const ADMIN_TABS = new Set(["themes", "times"]);
 
 export const state = {
     route: "reserve",
@@ -6,11 +6,12 @@ export const state = {
     themes: [],
     popularThemes: [],
     adminTimes: [],
-    reservations: [],
+    myReservations: [],
     availableTimes: [],
     selectedThemeId: null,
     selectedDate: tomorrowString(),
     selectedTimeId: null,
+    editingReservationId: null,
     guestName: "",
     themeQuery: "",
     loading: {

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -355,6 +355,20 @@ input:focus-visible {
     align-items: start;
 }
 
+.lookup-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+    align-items: start;
+}
+
+.lookup-layout .theme-section {
+    grid-column: 1;
+    grid-row: auto;
+    width: min(100%, 980px);
+    justify-self: center;
+}
+
 .reservation-grid.has-booking {
     grid-template-columns: 220px minmax(0, 1fr);
     padding-right: var(--booking-safe-space);
@@ -404,6 +418,10 @@ input:focus-visible {
     margin-bottom: 18px;
 }
 
+.section-toolbar.compact {
+    margin-bottom: 14px;
+}
+
 .section-toolbar > *,
 .admin-panel-header > *,
 .toolbar-actions {
@@ -448,6 +466,14 @@ input:focus-visible {
     border-color: rgba(229, 9, 20, 0.72);
     box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.12);
     background: #0f0f0f;
+}
+
+.search-field.wide {
+    width: 100%;
+}
+
+.search-field.wide input {
+    width: 100%;
 }
 
 .primary-button,
@@ -948,11 +974,32 @@ input:focus-visible {
     text-transform: uppercase;
 }
 
+.booking-mode-note {
+    display: block;
+    margin-top: 8px;
+    color: var(--muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.booking-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .selected-copy strong {
     display: block;
     margin-top: 4px;
     font-size: 1.12rem;
     line-height: 1.34;
+}
+
+.section-copy {
+    margin: 8px 0 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+    line-height: 1.55;
 }
 
 .selected-copy p {
@@ -1082,6 +1129,35 @@ input:focus-visible {
 .submit-button {
     width: 100%;
     min-height: 46px;
+}
+
+.my-reservations-section {
+    margin-top: 18px;
+    padding-top: 22px;
+    border-top: 1px solid var(--line);
+}
+
+.reservation-lookup-section {
+    padding-bottom: 22px;
+    border-bottom: 1px solid var(--line);
+}
+
+.lookup-row {
+    display: flex;
+    align-items: end;
+    gap: 12px;
+}
+
+.lookup-submit {
+    min-width: 88px;
+}
+
+.theme-toolbar {
+    margin-top: 22px;
+}
+
+.reservation-edit-section {
+    padding: 22px;
 }
 
 .panel-notice,
@@ -1248,6 +1324,21 @@ input:focus-visible {
 .table-row span {
     min-width: 0;
     overflow-wrap: anywhere;
+}
+
+.table-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+}
+
+.table-actions .secondary-button,
+.table-actions .danger-button,
+.booking-header-actions .secondary-button {
+    min-height: 34px;
+    padding: 0 12px;
+    font-size: 0.78rem;
 }
 
 .popular-skeleton,
@@ -1694,6 +1785,16 @@ input:focus-visible {
         padding: 14px;
         border: 1px solid var(--line);
         border-radius: 0;
+    }
+
+    .table-actions {
+        margin-top: 6px;
+        flex-wrap: wrap;
+    }
+
+    .booking-header-actions {
+        align-items: flex-start;
+        flex-direction: column;
     }
 }
 

--- a/src/test/java/roomescape/fake/FakeReservationQueryRepository.java
+++ b/src/test/java/roomescape/fake/FakeReservationQueryRepository.java
@@ -1,0 +1,25 @@
+package roomescape.fake;
+
+import lombok.RequiredArgsConstructor;
+import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.domain.repository.ReservationQueryRepository;
+
+@RequiredArgsConstructor
+public class FakeReservationQueryRepository implements ReservationQueryRepository {
+
+    private final FakeReservationRepository fakeReservationRepository;
+
+    @Override
+    public boolean existsByTimeId(Long timeId) {
+        return fakeReservationRepository.findAllReservations().stream()
+                .map(Reservation::getTimeId)
+                .anyMatch(timeId::equals);
+    }
+
+    @Override
+    public boolean existsByThemeId(Long themeId) {
+        return fakeReservationRepository.findAllReservations().stream()
+                .map(Reservation::getThemeId)
+                .anyMatch(themeId::equals);
+    }
+}

--- a/src/test/java/roomescape/fake/FakeReservationRepository.java
+++ b/src/test/java/roomescape/fake/FakeReservationRepository.java
@@ -5,16 +5,24 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.NoArgsConstructor;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.repository.ReservationDetail;
 import roomescape.reservation.domain.repository.ReservationRepository;
+import roomescape.reservationtime.domain.ReservationTime;
+import roomescape.theme.domain.Theme;
 
-@NoArgsConstructor
 public class FakeReservationRepository implements ReservationRepository {
 
+    private final FakeThemeRepository themeRepository;
+    private final FakeReservationTimeRepository timeRepository;
     private final Map<Long, Reservation> reservations = new LinkedHashMap<>();
     private Long idHolder = 1L;
+
+    public FakeReservationRepository(FakeThemeRepository themeRepository,
+                                     FakeReservationTimeRepository timeRepository) {
+        this.themeRepository = themeRepository;
+        this.timeRepository = timeRepository;
+    }
 
     @Override
     public List<ReservationDetail> findAll() {
@@ -31,6 +39,31 @@ public class FakeReservationRepository implements ReservationRepository {
     @Override
     public Optional<Reservation> findById(Long id) {
         return Optional.ofNullable(reservations.get(id));
+    }
+
+    @Override
+    public Optional<ReservationDetail> findDetailById(Long id) {
+        Reservation reservation = reservations.get(id);
+        if (reservation == null) {
+            return Optional.empty();
+        }
+
+        Theme theme = themeRepository.findById(reservation.getThemeId())
+                .orElseThrow();
+        ReservationTime reservationTime = timeRepository.findById(reservation.getTimeId())
+                .orElseThrow();
+
+        return Optional.of(new ReservationDetail(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getThemeId(),
+                theme.getName(),
+                theme.getDescription(),
+                theme.getThumbnailImgUrl(),
+                reservation.getTimeId(),
+                reservationTime.getStartAt()
+        ));
     }
 
     @Override

--- a/src/test/java/roomescape/fake/FakeReservationRepository.java
+++ b/src/test/java/roomescape/fake/FakeReservationRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.NoArgsConstructor;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.domain.repository.ReservationDetail;
@@ -21,10 +22,28 @@ public class FakeReservationRepository implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> findByName(String name) {
+        return reservations.values().stream()
+                .filter(reservation -> reservation.getName().equals(name))
+                .toList();
+    }
+
+    @Override
+    public Optional<Reservation> findById(Long id) {
+        return Optional.ofNullable(reservations.get(id));
+    }
+
+    @Override
     public Reservation save(Reservation reservation) {
         Reservation savedReservation = reservation.withId(idHolder);
         reservations.put(idHolder++, savedReservation);
         return savedReservation;
+    }
+
+    @Override
+    public Reservation update(Reservation reservation) {
+        reservations.put(reservation.getId(), reservation);
+        return reservation;
     }
 
     @Override
@@ -46,6 +65,15 @@ public class FakeReservationRepository implements ReservationRepository {
                 .anyMatch(savedReservation -> (savedReservation.getThemeId().equals(themeId) &&
                         savedReservation.getTimeId().equals(timeId) &&
                         savedReservation.getDate().equals(date)));
+    }
+
+    @Override
+    public Boolean existsByDateAndThemeAndTimeExcludingId(LocalDate date, Long themeId, Long timeId, Long id) {
+        return reservations.values().stream()
+                .filter(savedReservation -> !savedReservation.getId().equals(id))
+                .anyMatch(savedReservation -> savedReservation.getThemeId().equals(themeId)
+                        && savedReservation.getTimeId().equals(timeId)
+                        && savedReservation.getDate().equals(date));
     }
 
     public List<Reservation> findAllReservations() {

--- a/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
+++ b/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
@@ -1,5 +1,6 @@
 package roomescape.reservation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -8,8 +9,14 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -115,5 +122,76 @@ class ReservationApiIntegrationTest {
                 .when().delete("/reservations/{id}", reservationId)
                 .then().log().all()
                 .statusCode(204);
+    }
+
+    @DisplayName("동일한 예약 요청이 동시에 들어오면 1건만 성공하고 나머지는 409를 반환한다.")
+    @Test
+    void save_reservation_concurrently() throws Exception {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", "카야");
+        params.put("date", "2028-05-18");
+        params.put("themeId", themeId);
+        params.put("timeId", timeId);
+
+        int requestCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch readyLatch = new CountDownLatch(requestCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(requestCount);
+
+        List<Integer> statusCodes = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < requestCount; i++) {
+            executorService.submit(() -> {
+                readyLatch.countDown();
+                try {
+                    startLatch.await();
+
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .body(params)
+                            .when()
+                            .post("/reservations")
+                            .then()
+                            .extract()
+                            .statusCode();
+
+                    statusCodes.add(statusCode);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await();
+        executorService.shutdown();
+
+        long successCount = statusCodes.stream()
+                .filter(code -> code == 201)
+                .count();
+
+        long conflictCount = statusCodes.stream()
+                .filter(code -> code == 409)
+                .count();
+
+        assertThat(successCount).isEqualTo(1);
+        assertThat(conflictCount).isEqualTo(requestCount - 1);
+
+        Integer savedCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reservation WHERE date = ? AND theme_id = ? AND time_id = ?",
+                Integer.class,
+                LocalDate.of(2028, 5, 18),
+                themeId,
+                timeId
+        );
+
+        assertThat(savedCount).isEqualTo(1);
     }
 }

--- a/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
+++ b/src/test/java/roomescape/reservation/ReservationApiIntegrationTest.java
@@ -2,9 +2,11 @@ package roomescape.reservation;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -55,5 +57,63 @@ class ReservationApiIntegrationTest {
                 .body("time.startAt", equalTo("09:00"))
                 .body("theme.id", equalTo(themeId.intValue()))
                 .body("theme.name", equalTo("theme name"));
+    }
+
+    @DisplayName("이름으로 본인 예약 목록 조회 API를 테스트합니다.")
+    @Test
+    void find_my_reservations() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long firstTimeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        Long secondTimeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+        testHelper.insertReservation("스타크", LocalDate.of(2028, 5, 6), themeId, firstTimeId);
+        testHelper.insertReservation("스타크", LocalDate.of(2028, 5, 7), themeId, secondTimeId);
+        testHelper.insertReservation("카야", LocalDate.of(2028, 5, 8), themeId, secondTimeId);
+
+        RestAssured.given()
+                .queryParam("name", "스타크")
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(2))
+                .body("[0].name", equalTo("스타크"))
+                .body("[1].name", equalTo("스타크"));
+    }
+
+    @DisplayName("본인 예약 변경 API를 테스트합니다.")
+    @Test
+    void update_my_reservation() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long firstTimeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        Long secondTimeId = testHelper.insertReservationTime(LocalTime.of(10, 0));
+        Long reservationId = testHelper.insertReservation("스타크", LocalDate.of(2028, 5, 6), themeId, firstTimeId);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "스타크");
+        params.put("date", "2028-05-07");
+        params.put("timeId", String.valueOf(secondTimeId));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().patch("/reservations/{id}", reservationId)
+                .then().log().all()
+                .statusCode(200)
+                .body("id", equalTo(reservationId.intValue()))
+                .body("date", equalTo("2028-05-07"))
+                .body("time.id", equalTo(secondTimeId.intValue()));
+    }
+
+    @DisplayName("본인 예약 취소 API를 테스트합니다.")
+    @Test
+    void cancel_my_reservation() {
+        Long themeId = testHelper.insertTheme("theme name", "theme description", "theme img url");
+        Long timeId = testHelper.insertReservationTime(LocalTime.of(9, 0));
+        Long reservationId = testHelper.insertReservation("스타크", LocalDate.of(2028, 5, 6), themeId, timeId);
+
+        RestAssured.given()
+                .queryParam("name", "스타크")
+                .when().delete("/reservations/{id}", reservationId)
+                .then().log().all()
+                .statusCode(204);
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -16,6 +16,7 @@ import roomescape.fake.FakeThemeRepository;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.ReservationQueryResult;
+import roomescape.reservation.application.dto.ReservationUpdateCommand;
 import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
@@ -95,5 +96,91 @@ class ReservationServiceTest {
         Assertions.assertThatThrownBy(() -> reservationService.save(request, LocalDateTime.of(2026, 5, 6, 11, 0)))
                 .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
+    }
+
+    @DisplayName("이름으로 본인 예약 목록 조회를 테스트합니다.")
+    @Test
+    void find_reservations_by_name() {
+        themeService.save(new ThemeCreateCommand("theme name", "theme description", "theme img url"));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(10, 0)));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(11, 0)));
+
+        reservationService.save(
+                new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 6), 1L, 1L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+        reservationService.save(
+                new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 7), 1L, 2L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+        reservationService.save(
+                new ReservationCreateCommand("카야", LocalDate.of(2026, 5, 8), 1L, 2L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+
+        SoftAssertions.assertSoftly(assertSoftly -> {
+            assertSoftly.assertThat(reservationService.findAllByName("스타크")).hasSize(2);
+            assertSoftly.assertThat(reservationService.findAllByName("카야")).hasSize(1);
+        });
+    }
+
+    @DisplayName("본인 예약의 날짜와 시간을 변경합니다.")
+    @Test
+    void update_reservation() {
+        themeService.save(new ThemeCreateCommand("theme name", "theme description", "theme img url"));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(10, 0)));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(11, 0)));
+        reservationService.save(
+                new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 6), 1L, 1L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+
+        ReservationQueryResult updatedReservation = reservationService.update(
+                new ReservationUpdateCommand(1L, "스타크", LocalDate.of(2026, 5, 7), 2L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+
+        SoftAssertions.assertSoftly(assertSoftly -> {
+            assertSoftly.assertThat(updatedReservation.date()).isEqualTo(LocalDate.of(2026, 5, 7));
+            assertSoftly.assertThat(updatedReservation.time())
+                    .isEqualTo(new ReservationTimeQueryResult(2L, LocalTime.of(11, 0)));
+        });
+    }
+
+    @DisplayName("본인 이름이 아닌 경우 예약 변경 시 예외가 발생합니다.")
+    @Test
+    void update_other_users_reservation() {
+        themeService.save(new ThemeCreateCommand("theme name", "theme description", "theme img url"));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(10, 0)));
+        reservationService.save(
+                new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 6), 1L, 1L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+
+        Assertions.assertThatThrownBy(() -> reservationService.update(
+                        new ReservationUpdateCommand(1L, "카야", LocalDate.of(2026, 5, 7), 1L),
+                        LocalDateTime.of(2000, 1, 1, 0, 0)
+                ))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("본인의 예약만 변경하거나 취소할 수 있습니다.");
+    }
+
+    @DisplayName("지난 예약은 취소할 수 없습니다.")
+    @Test
+    void cancel_past_reservation() {
+        themeService.save(new ThemeCreateCommand("theme name", "theme description", "theme img url"));
+        timeService.save(new ReservationTimeCreateCommand(LocalTime.of(10, 0)));
+        reservationService.save(
+                new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 6), 1L, 1L),
+                LocalDateTime.of(2000, 1, 1, 0, 0)
+        );
+
+        Assertions.assertThatThrownBy(() -> reservationService.delete(
+                        1L,
+                        "스타크",
+                        LocalDateTime.of(2026, 5, 6, 11, 0)
+                ))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage("지난 예약은 변경하거나 취소할 수 없습니다.");
     }
 }

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -34,13 +34,15 @@ class ReservationServiceTest {
     private ReservationService reservationService;
     private FakeReservationRepository reservationRepository;
     private FakeReservationTimeRepository timeRepository;
+    private FakeThemeRepository themeRepository;
 
     @BeforeEach
     void setUp() {
-        reservationRepository = new FakeReservationRepository();
-        reservationQueryService = new ReservationQueryService(new FakeReservationQueryRepository(reservationRepository));
-        themeService = new ThemeService(new FakeThemeRepository(), reservationQueryService);
+        themeRepository = new FakeThemeRepository();
         timeRepository = new FakeReservationTimeRepository();
+        reservationRepository = new FakeReservationRepository(themeRepository, timeRepository);
+        reservationQueryService = new ReservationQueryService(new FakeReservationQueryRepository(reservationRepository));
+        themeService = new ThemeService(themeRepository, reservationQueryService);
         FakeAvailableReservationTimeRepository availableReservationTimeRepository =
                 new FakeAvailableReservationTimeRepository(timeRepository, reservationRepository);
         timeService = new ReservationTimeService(timeRepository, availableReservationTimeRepository,

--- a/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/reservation/service/ReservationServiceTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import roomescape.fake.FakeAvailableReservationTimeRepository;
+import roomescape.fake.FakeReservationQueryRepository;
 import roomescape.fake.FakeReservationRepository;
 import roomescape.fake.FakeReservationTimeRepository;
 import roomescape.fake.FakeThemeRepository;
+import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.dto.ReservationCreateCommand;
 import roomescape.reservation.application.dto.ReservationQueryResult;
-import roomescape.reservation.application.exception.ReservationException;
+import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.reservation.application.service.ReservationService;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
 import roomescape.reservationtime.application.dto.ReservationTimeQueryResult;
@@ -25,6 +27,7 @@ import roomescape.theme.application.service.ThemeService;
 
 class ReservationServiceTest {
 
+    private ReservationQueryService reservationQueryService;
     private ThemeService themeService;
     private ReservationTimeService timeService;
     private ReservationService reservationService;
@@ -33,12 +36,14 @@ class ReservationServiceTest {
 
     @BeforeEach
     void setUp() {
-        themeService = new ThemeService(new FakeThemeRepository());
         reservationRepository = new FakeReservationRepository();
+        reservationQueryService = new ReservationQueryService(new FakeReservationQueryRepository(reservationRepository));
+        themeService = new ThemeService(new FakeThemeRepository(), reservationQueryService);
         timeRepository = new FakeReservationTimeRepository();
         FakeAvailableReservationTimeRepository availableReservationTimeRepository =
                 new FakeAvailableReservationTimeRepository(timeRepository, reservationRepository);
-        timeService = new ReservationTimeService(timeRepository, availableReservationTimeRepository);
+        timeService = new ReservationTimeService(timeRepository, availableReservationTimeRepository,
+                reservationQueryService);
         reservationService = new ReservationService(reservationRepository, themeService, timeService);
     }
 
@@ -75,7 +80,7 @@ class ReservationServiceTest {
         ReservationCreateCommand secondRequest = new ReservationCreateCommand("카야", LocalDate.of(2026, 5, 6), 1L, 1L);
 
         Assertions.assertThatThrownBy(() -> reservationService.save(secondRequest, LocalDateTime.of(2000, 1, 1, 0, 0)))
-                .isInstanceOf(ReservationException.class)
+                .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("이미 해당 날짜와 시간에 예약이 존재합니다.");
     }
 
@@ -88,7 +93,7 @@ class ReservationServiceTest {
         ReservationCreateCommand request = new ReservationCreateCommand("스타크", LocalDate.of(2026, 5, 6), 1L, 1L);
 
         Assertions.assertThatThrownBy(() -> reservationService.save(request, LocalDateTime.of(2026, 5, 6, 11, 0)))
-                .isInstanceOf(ReservationException.class)
+                .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("현재 시간보다 이전 시간으로 예약을 할 수 없습니다.");
     }
 }

--- a/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
+++ b/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import roomescape.fake.FakeAvailableReservationTimeRepository;
+import roomescape.fake.FakeReservationQueryRepository;
 import roomescape.fake.FakeReservationRepository;
 import roomescape.fake.FakeReservationTimeRepository;
+import roomescape.global.RoomEscapeException;
 import roomescape.reservation.domain.Reservation;
+import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.reservationtime.application.dto.AvailableReservationTimeQueryResult;
 import roomescape.reservationtime.application.dto.ReservationTimeCreateCommand;
-import roomescape.reservationtime.application.exception.ReservationTimeException;
 import roomescape.reservationtime.application.service.ReservationTimeService;
 import roomescape.reservationtime.domain.ReservationTime;
 
@@ -24,6 +26,7 @@ class ReservationTimeServiceTest {
     private FakeReservationTimeRepository timeRepository;
     private FakeReservationRepository reservationRepository;
     private FakeAvailableReservationTimeRepository availableTimeRepository;
+    private ReservationQueryService reservationQueryService;
     private ReservationTimeService timeService;
 
     @BeforeEach
@@ -31,7 +34,8 @@ class ReservationTimeServiceTest {
         timeRepository = new FakeReservationTimeRepository();
         reservationRepository = new FakeReservationRepository();
         availableTimeRepository = new FakeAvailableReservationTimeRepository(timeRepository, reservationRepository);
-        timeService = new ReservationTimeService(timeRepository, availableTimeRepository);
+        reservationQueryService = new ReservationQueryService(new FakeReservationQueryRepository(reservationRepository));
+        timeService = new ReservationTimeService(timeRepository, availableTimeRepository, reservationQueryService);
 
         timeRepository.save(ReservationTime.builder()
                 .startAt(LocalTime.of(9, 0))
@@ -85,7 +89,7 @@ class ReservationTimeServiceTest {
         ReservationTimeCreateCommand createRequestDto = new ReservationTimeCreateCommand(LocalTime.of(9, 0));
 
         assertThatThrownBy(() -> timeService.save(createRequestDto))
-                .isInstanceOf(ReservationTimeException.class)
+                .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("시간 09:00이(가) 이미 존재합니다.");
     }
 }

--- a/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
+++ b/src/test/java/roomescape/reservationtime/service/ReservationTimeServiceTest.java
@@ -13,6 +13,7 @@ import roomescape.fake.FakeAvailableReservationTimeRepository;
 import roomescape.fake.FakeReservationQueryRepository;
 import roomescape.fake.FakeReservationRepository;
 import roomescape.fake.FakeReservationTimeRepository;
+import roomescape.fake.FakeThemeRepository;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.domain.Reservation;
 import roomescape.reservation.application.service.ReservationQueryService;
@@ -32,7 +33,7 @@ class ReservationTimeServiceTest {
     @BeforeEach
     void setUp() {
         timeRepository = new FakeReservationTimeRepository();
-        reservationRepository = new FakeReservationRepository();
+        reservationRepository = new FakeReservationRepository(new FakeThemeRepository(), timeRepository);
         availableTimeRepository = new FakeAvailableReservationTimeRepository(timeRepository, reservationRepository);
         reservationQueryService = new ReservationQueryService(new FakeReservationQueryRepository(reservationRepository));
         timeService = new ReservationTimeService(timeRepository, availableTimeRepository, reservationQueryService);

--- a/src/test/java/roomescape/support/ApiIntegrationTestHelper.java
+++ b/src/test/java/roomescape/support/ApiIntegrationTestHelper.java
@@ -11,6 +11,7 @@ public class ApiIntegrationTestHelper {
     private final JdbcTemplate jdbcTemplate;
     private final SimpleJdbcInsert themeInsert;
     private final SimpleJdbcInsert reservationTimeInsert;
+    private final SimpleJdbcInsert reservationInsert;
 
     public ApiIntegrationTestHelper(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -19,6 +20,9 @@ public class ApiIntegrationTestHelper {
                 .usingGeneratedKeyColumns("id");
         this.reservationTimeInsert = new SimpleJdbcInsert(jdbcTemplate)
                 .withTableName("reservation_time")
+                .usingGeneratedKeyColumns("id");
+        this.reservationInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("reservation")
                 .usingGeneratedKeyColumns("id");
     }
 
@@ -42,13 +46,12 @@ public class ApiIntegrationTestHelper {
         )).longValue();
     }
 
-    public void insertReservation(String name, LocalDate date, Long themeId, Long timeId) {
-        jdbcTemplate.update(
-                "INSERT INTO reservation (name, date, theme_id, time_id) VALUES (?, ?, ?, ?)",
-                name,
-                date,
-                themeId,
-                timeId
-        );
+    public Long insertReservation(String name, LocalDate date, Long themeId, Long timeId) {
+        return reservationInsert.executeAndReturnKey(Map.of(
+                "name", name,
+                "date", date,
+                "theme_id", themeId,
+                "time_id", timeId
+        )).longValue();
     }
 }

--- a/src/test/java/roomescape/theme/service/ThemeServiceTest.java
+++ b/src/test/java/roomescape/theme/service/ThemeServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import roomescape.fake.FakeReservationQueryRepository;
 import roomescape.fake.FakeReservationRepository;
+import roomescape.fake.FakeReservationTimeRepository;
 import roomescape.fake.FakeThemeRepository;
 import roomescape.global.RoomEscapeException;
 import roomescape.reservation.application.service.ReservationQueryService;
@@ -30,7 +31,9 @@ public class ThemeServiceTest {
     void setUp() {
         themeRepository = new FakeThemeRepository();
         reservationQueryService = new ReservationQueryService(
-                new FakeReservationQueryRepository(new FakeReservationRepository())
+                new FakeReservationQueryRepository(
+                        new FakeReservationRepository(themeRepository, new FakeReservationTimeRepository())
+                )
         );
         themeService = new ThemeService(themeRepository, reservationQueryService);
     }

--- a/src/test/java/roomescape/theme/service/ThemeServiceTest.java
+++ b/src/test/java/roomescape/theme/service/ThemeServiceTest.java
@@ -9,23 +9,30 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import roomescape.fake.FakeReservationQueryRepository;
+import roomescape.fake.FakeReservationRepository;
 import roomescape.fake.FakeThemeRepository;
+import roomescape.global.RoomEscapeException;
+import roomescape.reservation.application.service.ReservationQueryService;
 import roomescape.theme.application.dto.PopularThemeQueryResult;
 import roomescape.theme.application.dto.ThemeCreateCommand;
 import roomescape.theme.application.dto.ThemeQueryResult;
-import roomescape.theme.application.exception.ThemeException;
 import roomescape.theme.application.service.ThemeService;
 import roomescape.theme.domain.repository.PopularTheme;
 
 public class ThemeServiceTest {
 
     private FakeThemeRepository themeRepository;
+    private ReservationQueryService reservationQueryService;
     private ThemeService themeService;
 
     @BeforeEach
     void setUp() {
         themeRepository = new FakeThemeRepository();
-        themeService = new ThemeService(themeRepository);
+        reservationQueryService = new ReservationQueryService(
+                new FakeReservationQueryRepository(new FakeReservationRepository())
+        );
+        themeService = new ThemeService(themeRepository, reservationQueryService);
     }
 
     @DisplayName("테마의 정상 추가를 테스트합니다.")
@@ -51,7 +58,7 @@ public class ThemeServiceTest {
         themeService.save(createRequestDto);
 
         assertThatThrownBy(() -> themeService.save(createRequestDto))
-                .isInstanceOf(ThemeException.class)
+                .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("이름과 설명이 같은 테마가 이미 존재합니다.");
     }
 
@@ -86,7 +93,7 @@ public class ThemeServiceTest {
     @Test
     void theme_not_exists() {
         assertThatThrownBy(() -> themeService.findById(100L))
-                .isInstanceOf(ThemeException.class)
+                .isInstanceOf(RoomEscapeException.class)
                 .hasMessage("존재하지 않는 테마 입니다.");
     }
 


### PR DESCRIPTION
안녕하세요 주노!

사이클1 때 좋은 리뷰 남겨주셔서 감사합니다! 
이번 사이클2 리뷰도 잘 부탁드립니다! 🙇‍♂️
<!-- 

## 코드 리뷰 팁

- 코드와 관련된 질문이 있다면, PR 본문에 적기 보다는 해당 코드를 선택하고 코멘트를 남겨주세요.
  - [참고: Adding comments to a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-comments-to-a-pull-request)

-->
## 체크 리스트
- [x] 미션의 필수 요구사항을 모두 구현했나요?
- [x] Gradle `test`를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [x] 애플리케이션이 정상적으로 실행되나요?

## 베이스 코드 선택 체크
- [x] 이전 미션의 내 코드에서 시작 
- [ ] 이전 미션의 페어의 코드에서 시작

## 어떤 부분에 집중하여 리뷰해야 할까요?
<!-- 리뷰어가 효과적으로 피드백할 수 있도록 중점적으로 리뷰 받고 싶은 내용을 *요약* 형태로 작성해 주세요.
리뷰해야 할 포인트를 요약해 강조해 주시면, 리뷰어가 코드 전체를 이 부분에 집중해 리뷰할 수 있습니다.
반면 특정 코드부분에 대한 피드백이 필요하다면, 이 곳에 적기 보다 해당 코드를 선택하고 코멘트를 남기는 것을 권장합니다. -->

## 1. ReservationQueryService 분리
ReservationTimeService와 ThemeService에서 예약 존재 여부를 확인해야 했는데, 
기존 ReservationService를 직접 참조하면 순환 의존 가능성이 있어서 조회 전용 책임만 ReservationQueryService로 분리했습니다.
그래서 예약 생성/수정 같은 주요 유스케이스는 그대로 ReservationService에 두고, 다른 feature에서 필요로 하는 최소 조회 책임만 ReservationQueryService로 분리했습니다!
이처럼 feature 간에 필요한 최소 조회만 별도 service로 분리한 방식이 현재 구조에서 적절한지 의견을 듣고 싶습니다.

## 2. RoomEscapeException + ErrorCode enum
원래는 도메인별 예외 클래스를 사용했었는데, 이번에 예외를 좀 더 여러 케이스로 다루게 되면서
예외 클래스 수를 과도하게 늘리지 않기 위해 공통 RoomEscapeException 하나를 두고, 
도메인별 ErrorCode enum에서 HttpStatus와 메시지를 관리하도록 변경했습니다!
현재 프로젝트 규모에서는 이 방식이 적절한지, 아니면 도메인별 예외 클래스까지 유지하는 쪽이 더 나은지 궁금합니다.

## 3. my reservation을 별도 feature로 분리하지 않고 reservation에 확장한 구조
이번 단계에서 “내 예약 조회/변경/취소” 기능이 추가되면서, my reservation을 별도 feature로 분리할지 아니면
기존 reservation에 그대로 확장할지 고민했습니다.
도메인 자체는 기존 예약과 크게 다르지 않고, 사용하는 엔티티나 저장소도 동일해서 우선은 별도 feature를 만들기보다 
기존 reservation 패키지 안에 기능을 확장하는 방식으로 구현했습니다.

다만 유스케이스 관점에서는 “예약 생성/전체 조회”와 “내 예약 조회/변경/취소”가 분리된 흐름으로도 볼 수 있어서,
현재처럼 하나의 reservation 안에 두는 구조가 적절한지, 아니면 my reservation을 별도 feature로 분리하는 쪽이 더 자연스러운지 의견이 궁금합니다!